### PR TITLE
Add toolchain limit for nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        toolchain: [nightly, stable]
-        flags: ['', --all-features]
-        exclude:
-        - toolchain: stable
-          flags: --all-features
 
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ matrix.toolchain }}
+        toolchain: nightly-2021-07-22
         override: true
         components: clippy, rustfmt, rust-src, rustc-dev, llvm-tools-preview
     - run: cargo fmt -- --check

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2021-07-22"
+components = ["llvm-tools-preview","rustc-dev"]


### PR DESCRIPTION
Summary: Latest nightly is incompatible with previous versions in it's use of plugin_registrar, so pin the nightly version for now

Differential Revision: D31133087

